### PR TITLE
Filter out alpha channel in HDRIData

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -7,8 +7,8 @@ export function encodeRGBE(imageData: HDRImageData | ImageData): ArrayBuffer
 {
 	const hdriData: HDRImageData = imageData instanceof ImageData ? convertToHDRIData(imageData) : imageData;
 	const { width, height, data } = hdriData;
-    const encoded: number[] = [];
-    const hasAlpha = data.length === width * height * data.BYTES_PER_ELEMENT * 4;
+	const encoded: number[] = [];
+	const hasAlpha = data.length === width * height * data.BYTES_PER_ELEMENT * 4;
 
 	let header =
 		"#?RADIANCE\n# Made with derschmale/io-rgbe\n" +
@@ -34,9 +34,9 @@ export function encodeRGBE(imageData: HDRImageData | ImageData): ArrayBuffer
 			// gamma to linear
 			const r = data[i++];
 			const g = data[i++];
-            const b = data[i++];
-            // skip alpha channel if present
-            if (hasAlpha) i++;
+			const b = data[i++];
+			// skip alpha channel if present
+			if (hasAlpha) i++;
 
 			const maxComp = Math.max(r, g, b) / 256.0;
 			const e = clamp(Math.ceil(Math.log2(maxComp)) + 136, 0.0, 0xff);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -9,6 +9,7 @@ export function encodeRGBE(imageData: HDRImageData | ImageData): ArrayBuffer
 	const { width, height, data } = hdriData;
     const encoded: number[] = [];
     const hasAlpha = data.length === width * height * data.BYTES_PER_ELEMENT * 4;
+
 	let header =
 		"#?RADIANCE\n# Made with derschmale/io-rgbe\n" +
 		"EXPOSURE=" + hdriData.exposure + "\n" +
@@ -35,7 +36,7 @@ export function encodeRGBE(imageData: HDRImageData | ImageData): ArrayBuffer
 			const g = data[i++];
             const b = data[i++];
             // skip alpha channel if present
-            if(hasAlpha) i++;
+            if (hasAlpha) i++;
 
 			const maxComp = Math.max(r, g, b) / 256.0;
 			const e = clamp(Math.ceil(Math.log2(maxComp)) + 136, 0.0, 0xff);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -7,7 +7,8 @@ export function encodeRGBE(imageData: HDRImageData | ImageData): ArrayBuffer
 {
 	const hdriData: HDRImageData = imageData instanceof ImageData ? convertToHDRIData(imageData) : imageData;
 	const { width, height, data } = hdriData;
-	const encoded: number[] = [];
+    const encoded: number[] = [];
+    const hasAlpha = data.length === width * height * data.BYTES_PER_ELEMENT * 4;
 	let header =
 		"#?RADIANCE\n# Made with derschmale/io-rgbe\n" +
 		"EXPOSURE=" + hdriData.exposure + "\n" +
@@ -32,7 +33,10 @@ export function encodeRGBE(imageData: HDRImageData | ImageData): ArrayBuffer
 			// gamma to linear
 			const r = data[i++];
 			const g = data[i++];
-			const b = data[i++];
+            const b = data[i++];
+            // skip alpha channel if present
+            if(hasAlpha) i++;
+
 			const maxComp = Math.max(r, g, b) / 256.0;
 			const e = clamp(Math.ceil(Math.log2(maxComp)) + 136, 0.0, 0xff);
 			const sc = 1.0 / Math.pow(2, e - 136);


### PR DESCRIPTION
Hey there, thanks for all your work!

This PR fixes an edge case, where the encoded data would be corrupted if the input HDRImageData contained an alpha channel.